### PR TITLE
ci: exclude package from SonarQube static analysis for coverage

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ sonar {
 		property "sonar.projectKey", "estebancoloradogonzalez_denariousbackend"
 		property "sonar.organization", "estebancoloradogonzalez"
 		property "sonar.host.url", "https://sonarcloud.io"
-		property "sonar.coverage.exclusions", "**/com/denarious/transversal/domain/constant/.*, **/com/denarious/transversal/domain/message/.*, **/com/denarious/transversal/application/**, **/com/denarious/transaction/application/**, **/com/denarious/user/application/**"
+		property "sonar.coverage.exclusions", "**/com/denarious/transversal/infrastructure/configuration/.*, **/com/denarious/transversal/domain/constant/.*, **/com/denarious/transversal/domain/message/.*, **/com/denarious/transversal/application/**, **/com/denarious/transaction/application/**, **/com/denarious/user/application/**"
 		property "sonar.gradle.skipCompile", "true"
 	}
 }


### PR DESCRIPTION
Excluded specific package from SonarQube static analysis to improve coverage accuracy and avoid false negatives.