### PR TITLE
build: add exclusion of a class for Sonar static analysis coverage

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ sonar {
 		property "sonar.projectKey", "estebancoloradogonzalez_denariousbackend"
 		property "sonar.organization", "estebancoloradogonzalez"
 		property "sonar.host.url", "https://sonarcloud.io"
-		property "sonar.coverage.exclusions", "**/com/denarious/transversal/infrastructure/configuration/TransversalServiceBean.java, **/com/denarious/transversal/domain/constant/.*, **/com/denarious/transversal/domain/message/.*, **/com/denarious/transversal/application/**, **/com/denarious/transaction/application/**, **/com/denarious/user/application/**"
+		property "sonar.coverage.exclusions", "**/com/denarious/Application.java, **/com/denarious/transversal/infrastructure/configuration/TransversalServiceBean.java, **/com/denarious/transversal/domain/constant/.*, **/com/denarious/transversal/domain/message/.*, **/com/denarious/transversal/application/**, **/com/denarious/transaction/application/**, **/com/denarious/user/application/**"
 		property "sonar.gradle.skipCompile", "true"
 	}
 }


### PR DESCRIPTION
Excluded the specific class from Sonar's static analysis to avoid coverage issues and improve the accuracy of the analysis.